### PR TITLE
Fix for Ruby 3.2 changes

### DIFF
--- a/lib/best_in_place/display_methods.rb
+++ b/lib/best_in_place/display_methods.rb
@@ -2,7 +2,7 @@ module BestInPlace
   module DisplayMethods  #:nodoc:
     module_function
 
-    class Renderer < Struct.new(:opts)
+    class Renderer < Struct.new(:opts, keyword_init: false)
       def render_json(object)
         case opts[:type]
           when :model


### PR DESCRIPTION
Struct can be initialized by keyword arguments by default The default behavior of Struct since 3.2 is to accept both positional and keyword arguments in constructor.

The incompatibility might be introduced by code that expected singular hash as an argument for a Struct initialization:

ref: https://rubyreferences.github.io/rubychanges/3.2.html#struct-can-be-initialized-by-keyword-arguments-by-default